### PR TITLE
max disconuity from .5 -> 5

### DIFF
--- a/src/transformez/transform.py
+++ b/src/transformez/transform.py
@@ -563,7 +563,7 @@ class VerticalTransform:
                         shapefiles=coast_shapefiles,
                         decay_pixels=self.decay_pixels,
                         buffer_pixels=10,
-                        max_discontinuity=0.5,
+                        max_discontinuity=5,
                     )
                     desc.append(f"Blended w/ Global({proxy_name.upper()})")
                 else:


### PR DESCRIPTION
## Description

* Changes max disconuity between vdatum and fes from .5 to 5 meters.


---

#### Checklist

- [X] PR title is descriptive
- [X] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [X] If needed, `CHANGELOG.md` updated
- [X] If needed, docs and/or `README.md` updated
- [X] If needed, unit tests added
- [ ] All checks passing
- [ ] At least one approval


<!-- readthedocs-preview transformez start -->
---
:mag: Docs preview: https://transformez--53.org.readthedocs.build/en/53/

<!-- readthedocs-preview transformez end -->