### PR TITLE
force htdp 3.5.0, use htpd github page to fetch

### DIFF
--- a/src/transformez/cli.py
+++ b/src/transformez/cli.py
@@ -401,12 +401,17 @@ def htdp_group():
 
 
 @htdp_group.command("install", cls=FetchezMainCommand)
-def install_htdp():
-    """Downloads and compiles the HTDP executable."""
+@click.option(
+    "--version",
+    default="3.5.0",
+    help="HTDP version to install (e.g., 3.3.0, 3.5.0, 3.6.0)",
+)
+def install_htdp(version):
+    """Downloads and compiles the HTDP executable from github."""
 
     from transformez.htdp import install_htdp_binary
 
-    install_htdp_binary()
+    install_htdp_binary(version=version)
 
 
 # --- VDATUM CLI GROUP ---

--- a/src/transformez/grid_engine.py
+++ b/src/transformez/grid_engine.py
@@ -172,7 +172,7 @@ class GridEngine:
             #     error_msg = str(e)
 
             #     if "-101" in error_msg or "HDF error" in error_msg:
-            #         logger.error(f"🔥 CRITICAL: Corrupted NetCDF chunk detected in {fn}!")
+            #         logger.error(f" CRITICAL: Corrupted NetCDF chunk detected in {fn}!")
 
             #         # Extract the real file path from the GDAL netcdf string
             #         real_path = fn.split(":")[1] if fn.startswith("netcdf:") else fn

--- a/src/transformez/grid_engine.py
+++ b/src/transformez/grid_engine.py
@@ -22,6 +22,8 @@ from rasterio.transform import from_bounds
 from scipy import ndimage
 from scipy.interpolate import Rbf
 
+os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+
 logger = logging.getLogger(__name__)
 
 
@@ -139,6 +141,7 @@ class GridEngine:
 
             try:
                 with rasterio.open(fn) as src:
+                    # logger.info(f"{fn}: {src}")
                     src_data = src.read(1).astype(np.float32)
                     src_nodata = src.nodata
 
@@ -165,8 +168,29 @@ class GridEngine:
                     valid_mask = ~np.isnan(temp_buffer)
                     mosaic[valid_mask] = temp_buffer[valid_mask]
 
+            # except Exception as e:
+            #     error_msg = str(e)
+
+            #     if "-101" in error_msg or "HDF error" in error_msg:
+            #         logger.error(f"🔥 CRITICAL: Corrupted NetCDF chunk detected in {fn}!")
+
+            #         # Extract the real file path from the GDAL netcdf string
+            #         real_path = fn.split(":")[1] if fn.startswith("netcdf:") else fn
+
+            #         if os.path.exists(real_path):
+            #             logger.warning(f"Auto-deleting corrupted cache file: {real_path}")
+            #             os.remove(real_path)
+
+            #         raise RuntimeError(
+            #             f"Transformation aborted to prevent math corruption. "
+            #             f"The corrupted file has been deleted. Please re-run your command to fetch a fresh copy!"
+            #         )
+
+            #     # For all other normal errors, log and continue as usual
+            #     logger.exception(f"Failed to reproject {fn}: {e}")
+            #     continue
             except Exception as e:
-                logger.warning(f"Failed to reproject {fn}: {e}")
+                logger.exception(f"Failed to reproject {fn}: {e}")
                 continue
 
         # Fill inland areas (decaying to 0) before we clear the remaining NaNs

--- a/src/transformez/htdp.py
+++ b/src/transformez/htdp.py
@@ -16,6 +16,7 @@ import sys
 import os
 import subprocess
 import tempfile
+import shutil
 import logging
 import urllib.request
 import zipfile
@@ -40,11 +41,16 @@ HAS_HTDP = utils.cmd_check(f"htdp{ae}", htdp_cmd)
 class HTDP:
     """Wrapper for the NGS HTDP software."""
 
-    def __init__(self, htdp_bin: str = "htdp", verbose: bool = True):
+    def __init__(
+        self, htdp_bin: str = "htdp", version: str = "3.5.0", verbose: bool = True
+    ):
         self.htdp_bin = htdp_bin
+        self.version = version
         self.verbose = verbose
         if not HAS_HTDP:
-            logger.error("HTDP is not installed or not in PATH.")
+            logger.error(
+                f"HTDP {self.version} is not installed or not in PATH. Run 'transformez htdp install --version {self.version}"
+            )
 
     def run_grid(self, region, nx, ny, epsg_in, epsg_out, epoch_in, epoch_out):
         """Main entry point called by transform.py.
@@ -244,7 +250,61 @@ def download_htdp(target_dir=None):
             logger.error(f"Failed to download or extract HTDP source: {e}")
 
 
-def install_htdp_binary():
+def install_htdp_binary(version="3.5.0"):
+    """Downloads and automatically compiles a specific HTDP version from GitHub."""
+
+    cache_dir = os.path.join(os.getcwd(), "transformez_cache", "bin")
+    os.makedirs(cache_dir, exist_ok=True)
+
+    # Format the GitHub Tag (e.g., "v3.5.0")
+    v_tag = f"v{version}" if not version.startswith("v") else version
+    clean_version = v_tag.replace("v", "")
+
+    if sys.platform == "win32":
+        logger.info(f"Downloading Windows HTDP executable ({v_tag})...")
+        url = f"https://github.com/noaa-ngs/HTDP/releases/download/{v_tag}/htdp.exe"
+        exe_path = os.path.join(cache_dir, f"htdp_{clean_version}.exe")
+
+        try:
+            urllib.request.urlretrieve(url, exe_path)
+            logger.info(f"HTDP {clean_version} installed successfully to: {exe_path}")
+        except Exception as e:
+            logger.error(f"Failed to download {v_tag} from GitHub: {e}")
+
+    else:
+        logger.info(f"Downloading Unix HTDP source code ({v_tag})...")
+        url = f"https://github.com/noaa-ngs/HTDP/archive/refs/tags/{v_tag}.zip"
+        zip_path = os.path.join(cache_dir, f"htdp_{clean_version}.zip")
+
+        try:
+            urllib.request.urlretrieve(url, zip_path)
+
+            extract_dir = os.path.join(cache_dir, f"htdp_src_{clean_version}")
+            with zipfile.ZipFile(zip_path, "r") as z:
+                z.extractall(extract_dir)
+            os.remove(zip_path)
+
+            # GitHub extracts to a folder named Repository-Tag (e.g., HTDP-3.5.0)
+            source_folder = os.path.join(extract_dir, f"HTDP-{clean_version}")
+            fortran_file = os.path.join(source_folder, "htdp.f")
+            out_bin = os.path.join(cache_dir, f"htdp_{clean_version}")
+
+            logger.info(f"Compiling HTDP {clean_version} with gfortran...")
+            subprocess.run(
+                ["gfortran", "-o", out_bin, fortran_file],
+                check=True,
+                capture_output=True,
+            )
+            logger.info(f"HTDP compiled successfully to: {out_bin}")
+
+            # Clean up the raw source files
+            shutil.rmtree(extract_dir)
+
+        except Exception as e:
+            logger.error(f"Failed to install HTDP {clean_version}: {e}")
+
+
+def _install_htdp_binary():
     """Downloads and automatically compiles HTDP."""
 
     cache_dir = os.path.join(os.getcwd(), "transformez_cache", "bin")

--- a/src/transformez/transform.py
+++ b/src/transformez/transform.py
@@ -110,6 +110,7 @@ class VerticalTransform:
             region=self.region.to_list(),
             outdir=self.cache_dir,
             threads=2,
+            check_size=True,
             **kwargs,
         )
 
@@ -317,7 +318,7 @@ class VerticalTransform:
 
         try:
             logger.info(f"    [HTDP] Frame Shift: EPSG:{epsg_from} -> EPSG:{epsg_to}")
-            tool = htdp.HTDP(verbose=False)
+            tool = htdp.HTDP(version="3.5.0", verbose=False)
             grid = tool.run_grid(
                 self.region, self.nx, self.ny, epsg_from, epsg_to, epoch_from, epoch_to
             )


### PR DESCRIPTION
## Description

* HTDP has released a new version, 3.6.0 which is incompatible with currently available GEOIDs (12b, 18, etc). Thus, we must force the use of 3.5.0. Since they don't provide older versions from their static website, we must use their github page (with tags) to fetch the older versions until the new GEOID is released...


---

#### Checklist

- [X] PR title is descriptive
- [X] PR body contains links to related and resolved issues (e.g. `closes #1`)
- [X] If needed, `CHANGELOG.md` updated
- [X] If needed, docs and/or `README.md` updated
- [X] If needed, unit tests added
- [X] All checks passing
- [ ] At least one approval


<!-- readthedocs-preview transformez start -->
---
:mag: Docs preview: https://transformez--64.org.readthedocs.build/en/64/

<!-- readthedocs-preview transformez end -->